### PR TITLE
fix get_route function in distances - conversion from m to km added

### DIFF
--- a/co2calculator/_types.py
+++ b/co2calculator/_types.py
@@ -7,8 +7,8 @@ from typing import Union, TypedDict, Tuple, List
 
 Kilometer = float
 Kilograms = float
-Coordinates = Union[Tuple[float, float], List[float, float]]  # NOTE: double check/test
-# Python 3.9: Coordinates = tuple[float, float] | list[float, float]
+Coordinates = Union[Tuple[float, float], List[float]]  # NOTE: and/or Sequence? check!
+# Python 3.9: Coordinates = tuple[float, float] | list[float]
 
 
 class TrainStationDict(TypedDict):

--- a/co2calculator/_types.py
+++ b/co2calculator/_types.py
@@ -3,29 +3,5 @@
 
 """Type definitions for type checking purposes."""
 
-from typing import Union, TypedDict, Tuple, List
-
 Kilometer = float
-Kilograms = float
-Coordinates = Union[Tuple[float, float], List[float]]  # NOTE: and/or Sequence? check!
-# Python 3.9: Coordinates = tuple[float, float] | list[float]
-
-
-class TrainStationDict(TypedDict):
-    """Dictionary type for geocoding train stations"""
-
-    country: str
-    station_name: str
-
-
-# StructuredLocDict = dict[str, str]
-class StructuredLocDict(TypedDict, total=False):
-    """Dictionary type for structured geocoding with Pelias"""
-
-    country: str
-    region: str
-    county: str
-    locality: str
-    borough: str
-    address: str
-    neighbourhood: str
+Kilogram = float

--- a/co2calculator/_types.py
+++ b/co2calculator/_types.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Type definitions for type checking purposes."""
+
+from typing import Union, TypedDict, Tuple, List
+
+Kilometer = float
+Kilograms = float
+Coordinates = Union[Tuple[float, float], List[float, float]]  # NOTE: double check/test
+# Python 3.9: Coordinates = tuple[float, float] | list[float, float]
+
+
+class TrainStationDict(TypedDict):
+    """Dictionary type for geocoding train stations"""
+
+    country: str
+    station_name: str
+
+
+# StructuredLocDict = dict[str, str]
+class StructuredLocDict(TypedDict, total=False):
+    """Dictionary type for structured geocoding with Pelias"""
+
+    country: str
+    region: str
+    county: str
+    locality: str
+    borough: str
+    address: str
+    neighbourhood: str

--- a/co2calculator/calculate.py
+++ b/co2calculator/calculate.py
@@ -5,6 +5,7 @@
 import os
 from pathlib import Path
 from typing import Tuple
+from ._types import Kilogram, Kilometer
 import pandas as pd
 import warnings
 from .distances import haversine
@@ -21,12 +22,12 @@ detour_df = pd.read_csv(f"{script_path}/../data/detour.csv")
 
 
 def calc_co2_car(
-    distance: float = None,
+    distance: Kilometer = None,
     stops: list = None,
     passengers: int = None,
     size: str = None,
     fuel_type: str = None,
-) -> Tuple[float, float]:
+) -> Tuple[Kilogram, Kilometer]:
     """
     Function to compute the emissions of a car trip.
     :param distance: Distance travelled in km;
@@ -95,8 +96,8 @@ def calc_co2_car(
 
 
 def calc_co2_motorbike(
-    distance: float = None, stops: list = None, size: str = None
-) -> Tuple[float, float]:
+    distance: Kilometer = None, stops: list = None, size: str = None
+) -> Tuple[Kilogram, Kilometer]:
     """
     Function to compute the emissions of a motorbike trip.
     :param distance: Distance travelled in km;
@@ -145,7 +146,7 @@ def calc_co2_motorbike(
     return emissions, distance
 
 
-def apply_detour(distance, transportation_mode):
+def apply_detour(distance: Kilometer, transportation_mode: str) -> Kilometer:
     """
     Function to apply specific detour parameters to a distance as the crow flies
     :param distance: Distance as the crow flies between location of departure and destination of a trip
@@ -178,13 +179,13 @@ def apply_detour(distance, transportation_mode):
 
 
 def calc_co2_bus(
-    distance: float = None,
+    distance: Kilometer = None,
     stops: list = None,
     size: str = None,
     fuel_type: str = None,
     occupancy: int = None,
     vehicle_range: str = None,
-) -> Tuple[float, float]:
+) -> Tuple[Kilogram, Kilometer]:
     """
     Function to compute the emissions of a bus trip.
     :param distance: Distance travelled in km;
@@ -267,11 +268,11 @@ def calc_co2_bus(
 
 
 def calc_co2_train(
-    distance: float = None,
+    distance: Kilometer = None,
     stops: list = None,
     fuel_type: str = None,
     vehicle_range: str = None,
-) -> Tuple[float, float]:
+) -> Tuple[Kilogram, Kilometer]:
     """
     Function to compute the emissions of a train trip.
     :param distance: Distance travelled in km;
@@ -338,7 +339,7 @@ def calc_co2_train(
 
 def calc_co2_plane(
     start: str, destination: str, seating_class: str = None
-) -> Tuple[float, float]:
+) -> Tuple[Kilogram, Kilometer]:
     """
     Function to compute emissions of a plane trip
     :param start: IATA code of start airport
@@ -410,7 +411,7 @@ def calc_co2_plane(
 
 def calc_co2_ferry(
     start: dict, destination: dict, seating_class: str = None
-) -> Tuple[float, float]:
+) -> Tuple[Kilogram, Kilometer]:
     """
     Function to compute emissions of a ferry trip
     :param start: dictionary of location of start port,
@@ -454,7 +455,7 @@ def calc_co2_ferry(
 
 def calc_co2_electricity(
     consumption: float, fuel_type: str = None, energy_share: float = 1
-) -> float:
+) -> Kilogram:
     """Function to compute electricity emissions
 
     :param consumption: energy consumption
@@ -485,7 +486,7 @@ def calc_co2_electricity(
 
 def calc_co2_heating(
     consumption: float, fuel_type: str, unit: str = None, area_share: float = 1.0
-) -> float:
+) -> Kilogram:
     """Function to compute heating emissions
 
     :param consumption: energy consumption
@@ -547,14 +548,14 @@ def calc_co2_businesstrip(
     transportation_mode: str,
     start=None,
     destination=None,
-    distance: float = None,
+    distance: Kilometer = None,
     size: str = None,
     fuel_type: str = None,
     occupancy: int = None,
     seating: str = None,
     passengers: int = None,
     roundtrip: bool = False,
-) -> Tuple[float, float, str, str]:
+) -> Tuple[Kilogram, Kilometer, str, str]:
     """Function to compute emissions for business trips based on transportation mode and trip specifics
 
     :param transportation_mode: mode of transport [car, bus, train, plane, ferry]
@@ -653,7 +654,7 @@ def calc_co2_businesstrip(
     return emissions, dist, range_category, range_description
 
 
-def range_categories(distance: float) -> Tuple[str, str]:
+def range_categories(distance: Kilogram) -> Tuple[str, str]:
     """Function to categorize a trip according to the travelled distance
 
     :param distance: Distance travelled in km
@@ -680,12 +681,12 @@ def range_categories(distance: float) -> Tuple[str, str]:
 
 def calc_co2_commuting(
     transportation_mode: str,
-    weekly_distance: float = None,
+    weekly_distance: Kilometer = None,
     size: str = None,
     fuel_type: str = None,
     occupancy: int = None,
     passengers: int = None,
-) -> float:
+) -> Kilogram:
     """Calculate co2 emissions for commuting per mode of transport
 
     :param transportation_mode: [car, bus, train, bicycle, pedelec, motorbike, tram]
@@ -744,8 +745,8 @@ def calc_co2_commuting(
 
 
 def commuting_emissions_group(
-    aggr_co2: float, n_participants: int, n_members: int
-) -> float:
+    aggr_co2: Kilogram, n_participants: int, n_members: int
+) -> Kilogram:
     """Calculate the group's co2e emissions from commuting.
 
     .. note:: Assumption: a representative sample of group members answered the questionnaire.

--- a/co2calculator/distances.py
+++ b/co2calculator/distances.py
@@ -5,6 +5,7 @@
 
 
 from typing import Tuple
+from ._types import Kilometer, Coordinates, TrainStationDict, StructuredLocDict
 import numpy as np
 import openrouteservice
 from openrouteservice.directions import directions
@@ -25,8 +26,8 @@ script_path = str(Path(__file__).parent)
 
 def haversine(
     lat_start: float, long_start: float, lat_dest: float, long_dest: float
-) -> float:
-    """Function to compute the distance as the crown flies between given locations
+) -> Kilometer:
+    """Function to compute the distance as the crow flies between given locations
 
     :param lat_start: latitude of start
     :param long_start: Longitude of start
@@ -113,7 +114,7 @@ def geocoding(address):
     return name, country, coords
 
 
-def geocoding_structured(loc_dict):
+def geocoding_structured(loc_dict: StructuredLocDict):
     """Function to obtain coordinates for a given address
 
     :param loc_dict: dictionary describing the location.
@@ -190,7 +191,7 @@ def geocoding_structured(loc_dict):
     return name, country, coords, res
 
 
-def geocoding_train_stations(loc_dict):
+def geocoding_train_stations(loc_dict: TrainStationDict):
     """Function to obtain coordinates for a given train station
 
     :param loc_dict: dictionary describing the location.
@@ -278,7 +279,7 @@ def is_valid_geocoding_dict(geocoding_dict):
         )
 
 
-def get_route(coords: tuple, profile=None):
+def get_route(coords: Coordinates, profile: str = None) -> Kilometer:
     """Obtain the distance of a route between given waypoints using a given profile
 
     :param coords: list of [lat,long] coordinates

--- a/co2calculator/distances.py
+++ b/co2calculator/distances.py
@@ -297,6 +297,8 @@ def get_route(coords: tuple, profile=None):
             f"Profile set to '{profile}' by default."
         )
     route = directions(clnt, coords, profile=profile)
-    dist = route["routes"][0]["summary"]["distance"]
+    dist = (
+        route["routes"][0]["summary"]["distance"] / 1000
+    )  # divide my 1000, as we're working with distances in km
 
     return dist

--- a/co2calculator/distances.py
+++ b/co2calculator/distances.py
@@ -5,7 +5,7 @@
 
 
 from typing import Tuple
-from ._types import Kilometer, Coordinates, TrainStationDict, StructuredLocDict
+from ._types import Kilometer
 import numpy as np
 import openrouteservice
 from openrouteservice.directions import directions
@@ -114,7 +114,7 @@ def geocoding(address):
     return name, country, coords
 
 
-def geocoding_structured(loc_dict: StructuredLocDict):
+def geocoding_structured(loc_dict):
     """Function to obtain coordinates for a given address
 
     :param loc_dict: dictionary describing the location.
@@ -191,7 +191,7 @@ def geocoding_structured(loc_dict: StructuredLocDict):
     return name, country, coords, res
 
 
-def geocoding_train_stations(loc_dict: TrainStationDict):
+def geocoding_train_stations(loc_dict):
     """Function to obtain coordinates for a given train station
 
     :param loc_dict: dictionary describing the location.
@@ -279,7 +279,7 @@ def is_valid_geocoding_dict(geocoding_dict):
         )
 
 
-def get_route(coords: Coordinates, profile: str = None) -> Kilometer:
+def get_route(coords, profile: str = None) -> Kilometer:
     """Obtain the distance of a route between given waypoints using a given profile
 
     :param coords: list of [lat,long] coordinates


### PR DESCRIPTION
The `get_route` function in `distances.py` was getting the distance in m. This distance was used in the `calc_co2_car` function, leading to crazy high emissions. Conversion to km was added. 
https://github.com/pledge4future/co2calculator/blob/b53ea921aa7f1c9a65f3661c51be1b60122d1790/co2calculator/distances.py#L301 