### PR TITLE
Separate distance from co2 calc

### DIFF
--- a/co2calculator/calculate.py
+++ b/co2calculator/calculate.py
@@ -323,8 +323,13 @@ def calc_co2_train(
             coords.append(loc_coords)
         for i in range(len(coords) - 1):
             # compute great circle distance between locations
+            # NOTE: Unpacking failed (nested np.array) for me.
+            # Please check if my changes are valid!
             distance += haversine(
-                coords[i][1], coords[i][0], coords[i + 1][1], coords[i + 1][0]
+                coords[i][0][1],
+                coords[i][0][0],
+                coords[i + 1][0][1],
+                coords[i + 1][0][0],
             )
         distance = apply_detour(distance, transportation_mode=transport_mode)
     co2e = emission_factor_df[
@@ -597,26 +602,28 @@ def calc_co2_businesstrip(
         stops = None
     elif start is not None and destination is not None and distance is None:
         # check if stops are provided in the right form
-        # NOTE: transportation_mode 'car' requires string type for start and destination
-        if transportation_mode == "car" and (
-            type(start) != str or type(destination) != str
-        ):
-            # NOTE: I turned off that type check since lower level functions expect dicts
-            # (calc_co2_car & geo_coding_structured both want dictionaries)
-            pass
-            # raise ValueError(
-            #     "Wrong data type for start and destination."
-            #     "Please provide a three letter IATA code for train stations."
-            # )
-        elif transportation_mode != "car" and (
-            type(start) != dict or type(destination) != dict
-        ):
-            raise ValueError(
-                "Wrong data type for start and destination."
-                "Please provide a dictionary."
-            )
+
+        # NOTE: I turned off that type check since lower level functions expect dicts
+        # Failed for 'car', 'train' and 'plane'.
+        # It will come back within this branch after functional tests are set up!
+
+        # if transportation_mode == "car" and (
+        #     type(start) != str or type(destination) != str
+        # ):
+        #     raise ValueError(
+        #         "Wrong data type for start and destination."
+        #         "Please provide a three letter IATA code for train stations."
+        #     )
+        # elif transportation_mode != "car" and (
+        #     type(start) != dict or type(destination) != dict
+        # ):
+        #     raise ValueError(
+        #         "Wrong data type for start and destination."
+        #         "Please provide a dictionary."
+        #     )
 
         stops = [start, destination]
+
     if transportation_mode == "car":
         emissions, dist = calc_co2_car(
             distance=distance,

--- a/co2calculator/calculate.py
+++ b/co2calculator/calculate.py
@@ -597,13 +597,17 @@ def calc_co2_businesstrip(
         stops = None
     elif start is not None and destination is not None and distance is None:
         # check if stops are provided in the right form
+        # NOTE: transportation_mode 'car' requires string type for start and destination
         if transportation_mode == "car" and (
             type(start) != str or type(destination) != str
         ):
-            raise ValueError(
-                "Wrong data type for start and destination."
-                "Please provide a three letter IATA code for train stations."
-            )
+            # NOTE: I turned off that type check since lower level functions expect dicts
+            # (calc_co2_car & geo_coding_structured both want dictionaries)
+            pass
+            # raise ValueError(
+            #     "Wrong data type for start and destination."
+            #     "Please provide a three letter IATA code for train stations."
+            # )
         elif transportation_mode != "car" and (
             type(start) != dict or type(destination) != dict
         ):

--- a/co2calculator/distances.py
+++ b/co2calculator/distances.py
@@ -3,20 +3,22 @@
 
 """Functions for obtaining the distance between given addresses."""
 
-
+import os
+import warnings
+from pathlib import Path
 from typing import Tuple
-from ._types import Kilometer
+
 import numpy as np
 import openrouteservice
+import pandas as pd
+from dotenv import load_dotenv
 from openrouteservice.directions import directions
 from openrouteservice.geocode import pelias_search, pelias_structured
-import os
-from pathlib import Path
-from dotenv import load_dotenv
-import pandas as pd
 from thefuzz import fuzz
 from thefuzz import process
-import warnings
+
+from calculate import Coordinates  # TODO: Or implement coordinate model in this file?
+from ._types import Kilometer
 
 load_dotenv()  # take environment variables from .env.
 
@@ -24,25 +26,19 @@ ORS_API_KEY = os.environ.get("ORS_API_KEY")
 script_path = str(Path(__file__).parent)
 
 
-def haversine(
-    lat_start: float, long_start: float, lat_dest: float, long_dest: float
-) -> Kilometer:
+def haversine(start: Coordinates, dest: Coordinates) -> Kilometer:
     """Function to compute the distance as the crow flies between given locations
 
-    :param lat_start: latitude of start
-    :param long_start: Longitude of start
-    :param lat_dest: Latitude of destination
-    :param long_dest: Longitude of destination
-    :type lat_start: float
-    :type long_start: float
-    :type lat_dest: float
-    :type long_dest: float
+    :param start: Coordinates of start
+    :type start: Coordinates
+    :param dest: Coordinates of destination
+    :type dest: Coordinates
     :return: Distance in km
     :rtype: float
     """
     # convert angles from degree to radians
     lat_start, long_start, lat_dest, long_dest = np.deg2rad(
-        [lat_start, long_start, lat_dest, long_dest]
+        [start.lat, start.lng, dest.lat, dest.lng]
     )
     # compute zeta
     a = (

--- a/tests/functional/test_calculate.py
+++ b/tests/functional/test_calculate.py
@@ -65,8 +65,46 @@ class TestCalculateBusinessTrip:
                     "locality": "Berlin",
                     "address": "Alexanderplatz 1",
                 },
+                # NOTE: This seems slightly unrealistic.
+                # TODO: Please check business logic (can be different branch)!
                 134720.48,
                 id="transportation_mode: 'car'",
+            ),
+            pytest.param(
+                "bus",
+                {
+                    "address": "Im Neuenheimer Feld 348",
+                    "locality": "Heidelberg",
+                    "country": "Germany",
+                },
+                {
+                    "country": "Germany",
+                    "locality": "Berlin",
+                    "address": "Alexanderplatz 1",
+                },
+                28.3,
+                id="transportation_mode: 'bus'",
+            ),
+            pytest.param(
+                "train",
+                {"station_name": "Heidelberg Hbf", "country": "DE"},
+                {"station_name": "Berlin Hbf", "country": "DE"},
+                24.66,
+                id="transportation_mode: 'train'",
+            ),
+            pytest.param(
+                "plane",
+                "FRA",
+                "BER",
+                290.21,
+                id="transportation_mode: 'plane'",
+            ),
+            pytest.param(
+                "ferry",
+                {"locality": "Friedrichshafen", "country": "DE"},
+                {"locality": "Konstanz", "country": "DE"},
+                2.57,
+                id="transportation_mode: 'ferry'",
             ),
         ],
     )
@@ -82,7 +120,7 @@ class TestCalculateBusinessTrip:
         Expect: Happy path
         """
         # NOTE: IMPORTANT - Test currently makes real web calls!
-        # TODO: Mock!
+        # TODO: Record responses and mock external calls!
         actual_emissions, _, _, _ = candidate.calc_co2_businesstrip(
             transportation_mode=transportation_mode,
             start=start,

--- a/tests/functional/test_calculate.py
+++ b/tests/functional/test_calculate.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""WePledge has a python backend which uses co2calculator to number crunching.
+To ensure that the backend never has problems making existing calls, functional
+testing happens here.
+Functional testing should test all methods called at lower levels. External calls
+shall be mocked.
+Overview of used methods form backend:
+    - calc_co2_businesstrip,
+    - calc_co2_commuting,
+    - calc_co2_electricity,
+    - calc_co2_heating,
+"""
+from typing import Dict
+import pytest
+
+from co2calculator import calculate as candidate
+
+
+class TestCalculateBusinessTrip:
+    """Functional testing of business trip calculation calls from backend"""
+
+    @pytest.mark.parametrize(
+        "transportation_mode, expected_emissions",
+        [
+            pytest.param("car", 9.03, id="transportation_mode: 'car'"),
+            pytest.param("bus", 1.65, id="transportation_mode: 'bus'"),
+            pytest.param("train", 1.38, id="transportation_mode: 'train'"),
+        ],
+    )
+    def test_business_trip__distance_based(
+        self, transportation_mode: str, expected_emissions: float
+    ) -> None:
+        """Scenario: Backend asks for business trip calculation with distance input.
+        Test: co2 calculation for business trip
+        Expect: Happy path
+        """
+        actual_emissions, _, _, _ = candidate.calc_co2_businesstrip(
+            transportation_mode=transportation_mode,
+            start=None,
+            destination=None,
+            distance=42.0,
+            size=None,
+            fuel_type=None,
+            occupancy=None,
+            seating=None,
+            passengers=None,
+            roundtrip=False,
+        )
+
+        assert round(actual_emissions, 2) == expected_emissions
+
+    @pytest.mark.parametrize(
+        "transportation_mode, start, destination, expected_emissions",
+        [
+            pytest.param(
+                "car",
+                {
+                    "address": "Im Neuenheimer Feld 348",
+                    "locality": "Heidelberg",
+                    "country": "Germany",
+                },
+                {
+                    "country": "Germany",
+                    "locality": "Berlin",
+                    "address": "Alexanderplatz 1",
+                },
+                134720.48,
+                id="transportation_mode: 'car'",
+            ),
+        ],
+    )
+    def test_business_trip__stops_based(
+        self,
+        transportation_mode: str,
+        start: Dict,
+        destination: Dict,
+        expected_emissions: float,
+    ) -> None:
+        """Scenario: Backend asks for business trip calculation with distance input.
+        Test: co2 calculation for business trip
+        Expect: Happy path
+        """
+        # NOTE: IMPORTANT - Test currently makes real web calls!
+        # TODO: Mock!
+        actual_emissions, _, _, _ = candidate.calc_co2_businesstrip(
+            transportation_mode=transportation_mode,
+            start=start,
+            destination=destination,
+            distance=None,
+            size=None,
+            fuel_type=None,
+            occupancy=None,
+            seating=None,
+            passengers=None,
+            roundtrip=False,
+        )
+
+        assert round(actual_emissions, 2) == expected_emissions


### PR DESCRIPTION
* adapt WIP from https://github.com/akokam/co2calculator/blob/refactor-to-dry-code/co2calculator/calculate.py
* implement `DistanceRequest` and related models

@akokam This is nothing we have to merge eventually, I just wanted to try myself out on `pydantic`, experiment a bit and see if I understand how to use it. 
I built up on your work from January in the `refactor-to-dry-code` in your fork of the project (and your currently open PR "Separate distance from co2 calculation"). Unfortunately, the git diff is not so useful now, because you don't see what I added.. 
but maybe you can have a look at the classes `Stop`, `StopList` and `DistanceRequest`: https://github.com/pledge4future/co2calculator/blob/ff778b9ecb4d354fa01d7e3155dc12b85666dcb5/co2calculator/calculate.py#L53

I also added the functions `trip_direct` and `trip_detour`: https://github.com/pledge4future/co2calculator/blob/ff778b9ecb4d354fa01d7e3155dc12b85666dcb5/co2calculator/calculate.py#L80

And then I tried to add the distance calculation to the `calc_co2_buisnesstrip` function: https://github.com/pledge4future/co2calculator/blob/ff778b9ecb4d354fa01d7e3155dc12b85666dcb5/co2calculator/calculate.py#L487