### PR TITLE
add classes for detour coefficients and constants

### DIFF
--- a/co2calculator/constants.py
+++ b/co2calculator/constants.py
@@ -115,6 +115,20 @@ class RangeCategory(str, enum.Enum):
     LONG_HAUL = "long_haul"
 
 
+class DetourCoefficient(float, enum.Enum):
+    BUS = 1.5
+    TRAIN = 1.2
+    PLANE = 1.0
+    FERRY = 1.0
+
+
+class DetourConstant(float, enum.Enum):
+    BUS = 0.0
+    TRAIN = 0.0
+    PLANE = 95
+    FERRY = 0.0
+
+
 @enum.unique
 class TransportationMode(str, enum.Enum):
     CAR = "car"


### PR DESCRIPTION
Instead of reading from a csv-file, add a class to `constants.py` with detour coefficients and constants